### PR TITLE
Empty callback function for writeFile() calls

### DIFF
--- a/pl2html.js
+++ b/pl2html.js
@@ -69,10 +69,10 @@ glob(patternDir + '/*+(templates|pages)*/*.html', globOpts, function(er, files) 
       outFile = cleanFilename(fn);
       if (err) {
         console.log(err);
-        fs.writeFile(outDir + '/' + outFile, lines);
+        fs.writeFile(outDir + '/' + outFile, lines, () => {});
       }
       else {
-        fs.writeFile(outDir + '/' + outFile, html);
+        fs.writeFile(outDir + '/' + outFile, html, () => {});
       }
     });
   });


### PR DESCRIPTION
Related to #2

I tested this change in a NewCity project, and it resolved the issue without seeming to cause any problems.